### PR TITLE
Add restcomm snapshots repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,4 +151,12 @@
             </plugin>
         </plugins>
     </build>
+    <repositories>
+        <repository>
+            <id>cxs-snapshot</id>
+            <url>http://cxsnexus.restcomm.com/nexus/content/repositories/snapshots</url>
+            <releases><enabled>false</enabled></releases>
+            <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
this prevents build failures that happen with the following error message when you clone and try to build locally: 

```
[FATAL] Non-resolvable parent POM for org.restcomm.media.server:media-server-standalone:8.0.0-SNAPSHOT: Could not find artifact org.restcomm.media:media-parent:pom:8.0.0-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 6, column 13
```

This way we don't have to ask user to manually add this to their `~/.m2/settings.xml`